### PR TITLE
Integrate feeAccount + platformFeeBps for Swaps % fees.

### DIFF
--- a/sdk/src/driftClient.ts
+++ b/sdk/src/driftClient.ts
@@ -5091,7 +5091,6 @@ export class DriftClient {
 		v6,
 		quote,
 		onlyDirectRoutes = false,
-		wrapAndUnwrapSOL,
 		feeAccount,
 	}: {
 		jupiterClient: JupiterClient;
@@ -5109,7 +5108,6 @@ export class DriftClient {
 			quote?: QuoteResponse;
 		};
 		quote?: QuoteResponse;
-		wrapAndUnwrapSOL?: boolean;
 		feeAccount?: string;
 	}): Promise<TransactionSignature> {
 		const quoteToUse = quote ?? v6?.quote;
@@ -5126,7 +5124,6 @@ export class DriftClient {
 			quote: quoteToUse,
 			reduceOnly,
 			onlyDirectRoutes,
-			wrapAndUnwrapSOL,
 			feeAccount,
 		});
 		const ixs = res.ixs;
@@ -5159,7 +5156,6 @@ export class DriftClient {
 		quote,
 		reduceOnly,
 		userAccountPublicKey,
-		wrapAndUnwrapSOL,
 		feeAccount,
 	}: {
 		jupiterClient: JupiterClient;
@@ -5174,7 +5170,6 @@ export class DriftClient {
 		quote?: QuoteResponse;
 		reduceOnly?: SwapReduceOnly;
 		userAccountPublicKey?: PublicKey;
-		wrapAndUnwrapSOL?: boolean;
 		feeAccount?: string;
 	}): Promise<{
 		ixs: TransactionInstruction[];
@@ -5208,7 +5203,6 @@ export class DriftClient {
 			quote,
 			userPublicKey: this.provider.wallet.publicKey,
 			slippageBps,
-			wrapAndUnwrapSOL,
 			feeAccount,
 		});
 

--- a/sdk/src/driftClient.ts
+++ b/sdk/src/driftClient.ts
@@ -5091,6 +5091,8 @@ export class DriftClient {
 		v6,
 		quote,
 		onlyDirectRoutes = false,
+		wrapAndUnwrapSOL,
+		feeAccount,
 	}: {
 		jupiterClient: JupiterClient;
 		outMarketIndex: number;
@@ -5107,6 +5109,8 @@ export class DriftClient {
 			quote?: QuoteResponse;
 		};
 		quote?: QuoteResponse;
+		wrapAndUnwrapSOL?: boolean;
+		feeAccount?: string;
 	}): Promise<TransactionSignature> {
 		const quoteToUse = quote ?? v6?.quote;
 
@@ -5122,6 +5126,8 @@ export class DriftClient {
 			quote: quoteToUse,
 			reduceOnly,
 			onlyDirectRoutes,
+			wrapAndUnwrapSOL,
+			feeAccount,
 		});
 		const ixs = res.ixs;
 		const lookupTables = res.lookupTables;
@@ -5153,6 +5159,8 @@ export class DriftClient {
 		quote,
 		reduceOnly,
 		userAccountPublicKey,
+		wrapAndUnwrapSOL,
+		feeAccount,
 	}: {
 		jupiterClient: JupiterClient;
 		outMarketIndex: number;
@@ -5166,6 +5174,8 @@ export class DriftClient {
 		quote?: QuoteResponse;
 		reduceOnly?: SwapReduceOnly;
 		userAccountPublicKey?: PublicKey;
+		wrapAndUnwrapSOL?: boolean;
+		feeAccount?: string;
 	}): Promise<{
 		ixs: TransactionInstruction[];
 		lookupTables: AddressLookupTableAccount[];
@@ -5198,6 +5208,8 @@ export class DriftClient {
 			quote,
 			userPublicKey: this.provider.wallet.publicKey,
 			slippageBps,
+			wrapAndUnwrapSOL,
+			feeAccount,
 		});
 
 		const { transactionMessage, lookupTables } =

--- a/sdk/src/jupiter/jupiterClient.ts
+++ b/sdk/src/jupiter/jupiterClient.ts
@@ -258,6 +258,7 @@ export class JupiterClient {
 		autoSlippage = false,
 		maxAutoSlippageBps,
 		usdEstimate,
+		platformFeeBps,
 	}: {
 		inputMint: PublicKey;
 		outputMint: PublicKey;
@@ -270,6 +271,7 @@ export class JupiterClient {
 		autoSlippage?: boolean;
 		maxAutoSlippageBps?: number;
 		usdEstimate?: number;
+		platformFeeBps?: number;
 	}): Promise<QuoteResponse> {
 		const params = new URLSearchParams({
 			inputMint: inputMint.toString(),
@@ -285,6 +287,7 @@ export class JupiterClient {
 				? usdEstimate.toString()
 				: '0',
 			...(excludeDexes && { excludeDexes: excludeDexes.join(',') }),
+			...(platformFeeBps && { platformFeeBps: platformFeeBps.toString() }),
 		});
 		if (swapMode === 'ExactOut') {
 			params.delete('maxAccounts');
@@ -304,15 +307,20 @@ export class JupiterClient {
 	 * @param quoteResponse quote to perform swap
 	 * @param userPublicKey the signer's wallet public key
 	 * @param slippageBps the slippage tolerance in basis points
+	 * @param feeAccount the fee account to use for the swap
 	 */
 	public async getSwap({
 		quote,
 		userPublicKey,
 		slippageBps = 50,
+		wrapAndUnwrapSOL = undefined,
+		feeAccount,
 	}: {
 		quote: QuoteResponse;
 		userPublicKey: PublicKey;
 		slippageBps?: number;
+		wrapAndUnwrapSOL?: boolean;
+		feeAccount?: string;
 	}): Promise<VersionedTransaction> {
 		if (!quote) {
 			throw new Error('Jupiter swap quote not provided. Please try again.');
@@ -332,6 +340,8 @@ export class JupiterClient {
 					quoteResponse: quote,
 					userPublicKey,
 					slippageBps,
+					wrapAndUnwrapSOL,
+					feeAccount,
 				}),
 			})
 		).json();

--- a/sdk/src/jupiter/jupiterClient.ts
+++ b/sdk/src/jupiter/jupiterClient.ts
@@ -313,13 +313,11 @@ export class JupiterClient {
 		quote,
 		userPublicKey,
 		slippageBps = 50,
-		wrapAndUnwrapSOL = undefined,
 		feeAccount,
 	}: {
 		quote: QuoteResponse;
 		userPublicKey: PublicKey;
 		slippageBps?: number;
-		wrapAndUnwrapSOL?: boolean;
 		feeAccount?: string;
 	}): Promise<VersionedTransaction> {
 		if (!quote) {
@@ -340,7 +338,6 @@ export class JupiterClient {
 					quoteResponse: quote,
 					userPublicKey,
 					slippageBps,
-					wrapAndUnwrapSOL,
 					feeAccount,
 				}),
 			})


### PR DESCRIPTION
gm, while I was integrating getJupiterSwapIxV6 I realized that there was no feeAccount and platformBps integration for swaps to get % fee from user.  I modified the SDK, specifically the JupiterClient/DriftClient and added for the getJupiterSwapIxV6. 

This pull request may be useful, so I opened just in case.

