### PR TITLE
Fix 'recieved' typo in comment

### DIFF
--- a/programs/drift/src/controller/orders.rs
+++ b/programs/drift/src/controller/orders.rs
@@ -4777,7 +4777,7 @@ fn fulfill_spot_order(
             context,
         )?;
 
-    // user hasnt recieved initial fuel or below global start time
+    // user hasnt received initial fuel or below global start time
     user_stats.update_fuel_bonus(
         user,
         taker_margin_calculation.fuel_deposits,


### PR DESCRIPTION
Minor typo in a code comment: `recieved` should be `received` (programs/drift/src/controller/orders.rs). No code change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected an internal comment describing spot order fulfillment conditions.
  * No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->