### PR TITLE
Fix APR math in nextRevenuePoolSettleApr

### DIFF
--- a/sdk/src/math/insurance.ts
+++ b/sdk/src/math/insurance.ts
@@ -17,7 +17,7 @@ export function nextRevenuePoolSettleApr(
 		SpotBalanceType.DEPOSIT
 	);
 
-	const payoutRatio = 0.1;
+	const payoutRatioDenominator = 10;
 	const ratioForStakers =
 		spotMarket.insuranceFund.totalFactor > 0 &&
 		spotMarket.insuranceFund.userFactor > 0 &&
@@ -34,11 +34,13 @@ export function nextRevenuePoolSettleApr(
 
 	const projectedAnnualRev = revenuePoolBN
 		.muln(settlesPerYear)
-		.muln(payoutRatio);
+		.divn(payoutRatioDenominator);
 
-	const uncappedApr = vaultBalance.add(amount).eq(ZERO)
+	const delta = amount ?? ZERO;
+
+	const uncappedApr = vaultBalance.add(delta).eq(ZERO)
 		? 0
-		: projectedAnnualRev.muln(1000).div(vaultBalance.add(amount)).toNumber() *
+		: projectedAnnualRev.muln(1000).div(vaultBalance.add(delta)).toNumber() *
 		  100 *
 		  1000;
 	const cappedApr = Math.min(uncappedApr, MAX_APR.toNumber());

--- a/sdk/src/math/insurance.ts
+++ b/sdk/src/math/insurance.ts
@@ -30,10 +30,9 @@ export function nextRevenuePoolSettleApr(
 	const revSettlePeriod =
 		spotMarket.insuranceFund.revenueSettlePeriod.toNumber() * 1000;
 
-	const settlesPerYear = 31536000000 / revSettlePeriod;
-
 	const projectedAnnualRev = revenuePoolBN
-		.muln(settlesPerYear)
+		.mul(new BN(31536000000))
+		.div(new BN(revSettlePeriod))
 		.divn(payoutRatioDenominator);
 
 	const delta = amount ?? ZERO;


### PR DESCRIPTION
`nextRevenuePoolSettleApr` in `sdk/src/math/insurance.ts` has two bugs:

1. `revenuePoolBN.muln(settlesPerYear).muln(payoutRatio)` with `payoutRatio = 0.1`. `BN.muln` does not multiply by a fraction; it multiplies each limb and masks, so a fractional argument yields garbage rather than `value * 0.1`. For example `new BN(1_000_000_000).muln(0.1)` returns `73156454`, not `100000000` (about 27 percent off). Since `payoutRatio` is the constant `0.1`, this is integer `divn(10)`.

2. `amount` is declared optional (`amount?: BN`), but `vaultBalance.add(amount)` is called unconditionally, so `add(undefined)` throws when a caller omits it. Defaulting a missing delta to `ZERO` preserves the intended behavior.

The function is exported from the SDK (`export * from './math/insurance'`), so both reach downstream consumers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved revenue pool settlement APR calculations for more accurate payout projections.
  * Prevented missing optional amounts from causing invalid APR results.
  * Updated APR calculations to use integer-based payout handling for greater consistency.
  * Improved the reliability of projected revenue and vault balance calculations when no additional amount is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->